### PR TITLE
Update RecursiveArrayTools to the latest version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Lazy = "0.14, 0.15"
-RecursiveArrayTools = "1.0.2, 2.0"
+RecursiveArrayTools = "1.0.2, 2.0, 3"
 Reexport = "0.2, 1.0"
 julia = "1"
 


### PR DESCRIPTION
I need to upgrade the deps to fix a compatibility issue in package Bloqade.jl, can we release a patch version after merging this PR?